### PR TITLE
Update platformtree for new rust

### DIFF
--- a/platformtree/src/builder/meta_args.rs
+++ b/platformtree/src/builder/meta_args.rs
@@ -63,7 +63,7 @@ fn set_tasks(cx: &mut ExtCtxt, tasks: Vec<P<ast::MetaItem>>) {
   let mut vec_clone = cx.cfg();
   let maybe_pos = vec_clone.iter().position(|i| {
     match i.node {
-      ast::MetaList(ref k, _) if *k == TAG => true,
+      ast::MetaItemKind::List(ref k, _) if *k == TAG => true,
       _ => false,
     }
   });
@@ -80,7 +80,7 @@ fn set_tasks(cx: &mut ExtCtxt, tasks: Vec<P<ast::MetaItem>>) {
 fn get_tasks(cx: &ExtCtxt) -> Vec<P<ast::MetaItem>> {
   for i in cx.cfg.iter() {
     match i.node {
-      ast::MetaList(ref k, ref v) if *k == TAG => return v.clone(),
+      ast::MetaItemKind::List(ref k, ref v) if *k == TAG => return v.clone(),
       _ => (),
     }
   };
@@ -92,10 +92,10 @@ fn get_task(tasks: &Vec<P<ast::MetaItem>>, task: &str) -> Vec<String> {
   let mut ty_params = vec!();
   for mi in tasks.iter() {
     match mi.node {
-      ast::MetaList(ref k, ref v) if *k == task => {
+      ast::MetaItemKind::List(ref k, ref v) if *k == task => {
         for submi in v.iter() {
           match submi.node {
-            ast::MetaWord(ref w) => ty_params.push((&*w).to_string()),
+            ast::MetaItemKind::Word(ref w) => ty_params.push((&*w).to_string()),
             _ => panic!("unexpected node type"),
           }
         }
@@ -125,11 +125,11 @@ fn get_task(tasks: &Vec<P<ast::MetaItem>>, task: &str) -> Vec<String> {
 // fn get_args(cx: &ExtCtxt) -> Option<Vec<MetaArgs>> {
 //   cx.cfg.iter().find(|i| {
 //     match i.node {
-//       ast::MetaList(ref k, _) => k.get() == TAG,
+//       ast::MetaItemKind::List(ref k, _) => k.get() == TAG,
 //       _ => false,
 //     }
 //   }).and_then(|i| match i.node {
-//     ast::MetaList(_, ref v) => Some(meta_item_to_meta_args(v)),
+//     ast::MetaItemKind::List(_, ref v) => Some(meta_item_to_meta_args(v)),
 //     _ => panic!(),
 //   })
 // }

--- a/platformtree/src/builder/mod.rs
+++ b/platformtree/src/builder/mod.rs
@@ -32,7 +32,7 @@ mod os;
 pub mod meta_args;
 
 pub struct Builder {
-  main_stmts: Vec<P<ast::Stmt>>,
+  main_stmts: Vec<ast::Stmt>,
   type_items: Vec<P<ast::Item>>,
   pt: Rc<node::PlatformTree>,
 }
@@ -120,7 +120,7 @@ impl Builder {
   }
 
   pub fn new(pt: Rc<node::PlatformTree>, cx: &ExtCtxt) -> Builder {
-    let use_zinc = cx.item_use_simple(DUMMY_SP, ast::Inherited, cx.path_ident(
+    let use_zinc = cx.item_use_simple(DUMMY_SP, ast::Visibility::Inherited, cx.path_ident(
         DUMMY_SP, cx.ident_of("zinc")));
 
     Builder {
@@ -130,7 +130,7 @@ impl Builder {
     }
   }
 
-  pub fn main_stmts(&self) -> Vec<P<ast::Stmt>> {
+  pub fn main_stmts(&self) -> Vec<ast::Stmt> {
     self.main_stmts.clone()
   }
 
@@ -138,7 +138,7 @@ impl Builder {
     self.pt.clone()
   }
 
-  pub fn add_main_statement(&mut self, stmt: P<ast::Stmt>) {
+  pub fn add_main_statement(&mut self, stmt: ast::Stmt) {
     self.main_stmts.push(stmt);
   }
 
@@ -228,14 +228,14 @@ impl Builder {
       ident: cx.ident_of(name),
       attrs: attrs,
       id: ast::DUMMY_NODE_ID,
-      node: ast::ItemFn(
-          cx.fn_decl(Vec::new(), cx.ty(DUMMY_SP, ast::Ty_::TyTup(Vec::new()))),
+      node: ast::ItemKind::Fn(
+          cx.fn_decl(Vec::new(), cx.ty(DUMMY_SP, ast::TyKind::Tup(Vec::new()))),
           ast::Unsafety::Unsafe,
           ast::Constness::NotConst,
-          abi::Rust, // TODO(farcaller): should this be abi::C?
+          abi::Abi::Rust, // TODO(farcaller): should this be abi::Abi::C?
           ast::Generics::default(),
           body),
-      vis: ast::Public,
+      vis: ast::Visibility::Public,
       span: span,
     })
   }

--- a/platformtree/src/builder/os.rs
+++ b/platformtree/src/builder/os.rs
@@ -117,7 +117,7 @@ fn build_args(builder: &mut Builder, cx: &mut ExtCtxt,
           DUMMY_SP,
           cx.ty_ident(DUMMY_SP, cx.ident_of("str")),
           Some(static_lifetime),
-          ast::MutImmutable), quote_expr!(&*cx, $val_slice))
+          ast::Mutability::Immutable), quote_expr!(&*cx, $val_slice))
       },
       node::RefValue(ref rname)  => {
         let refnode = builder.pt.get_by_name(rname.as_str()).unwrap();
@@ -134,12 +134,12 @@ fn build_args(builder: &mut Builder, cx: &mut ExtCtxt,
           DUMMY_SP,
           cx.ty_path(type_name_as_path(cx, reftype.as_str(), refparams)),
           Some(a_lifetime),
-          ast::MutImmutable), quote_expr!(&*cx, &$val_slice))
+          ast::Mutability::Immutable), quote_expr!(&*cx, &$val_slice))
       },
     };
     let name_ident = cx.ident_of(k.as_str());
     let sf = ast::StructField_ {
-      kind: ast::NamedField(name_ident, ast::Public),
+      kind: ast::NamedField(name_ident, ast::Visibility::Public),
       id: ast::DUMMY_NODE_ID,
       ty: ty,
       attrs: vec!(),
@@ -169,7 +169,7 @@ fn build_args(builder: &mut Builder, cx: &mut ExtCtxt,
     ident: name_ident,
     attrs: vec!(),
     id: ast::DUMMY_NODE_ID,
-    node: ast::ItemStruct(
+    node: ast::ItemKind::Struct(
       ast::VariantData::Struct(fields, ast::DUMMY_NODE_ID),
       ast::Generics {
         lifetimes: vec!(cx.lifetime_def(DUMMY_SP, intern("'a"), vec!())),
@@ -179,7 +179,7 @@ fn build_args(builder: &mut Builder, cx: &mut ExtCtxt,
           predicates: vec!(),
         }
       }),
-      vis: ast::Public,
+      vis: ast::Visibility::Public,
       span: DUMMY_SP,
   });
   builder.add_type_item(struct_item);

--- a/platformtree/src/parser.rs
+++ b/platformtree/src/parser.rs
@@ -16,7 +16,7 @@
 use std::ops::Deref;
 use std::collections::HashMap;
 use std::rc::{Rc, Weak};
-use syntax::ast::{TokenTree, LitInt, UnsuffixedIntLit};
+use syntax::ast::{TokenTree, LitKind, LitIntType};
 use syntax::codemap::{Span, mk_sp};
 use syntax::ext::base::ExtCtxt;
 use syntax::parse::{token, ParseSess, lexer, integer_lit};
@@ -186,7 +186,7 @@ impl<'a> Parser<'a> {
 
         let lit = integer_lit(intname.as_str().deref(), None, &self.sess.span_diagnostic, self.span);
         match lit {
-          LitInt(i, _) => {
+          LitKind::Int(i, _) => {
             format!("{}", i)
           },
           _ => {
@@ -345,7 +345,7 @@ impl<'a> Parser<'a> {
         if suffix.is_none() {
           let lit = integer_lit(intname.as_str().deref(), None, &self.sess.span_diagnostic, self.span);
           match lit {
-            LitInt(i, UnsuffixedIntLit(_)) => {
+            LitKind::Int(i, LitIntType::Unsuffixed) => {
               self.bump();
               Some(node::IntValue(i as usize))
             },


### PR DESCRIPTION
`platformtree` was still using old types.
Note: `Builder::main_stmts` is now a simple `Vec<ast::Stmt>`.
