### PR TITLE
Update macro_platformtree to latest rust

### DIFF
--- a/ioreg/src/builder/getter.rs
+++ b/ioreg/src/builder/getter.rs
@@ -17,7 +17,6 @@ use std::iter::FromIterator;
 use std::ops::Deref;
 
 use syntax::ast;
-use syntax::parse::token;
 use syntax::ptr::P;
 use syntax::ext::base::ExtCtxt;
 use syntax::codemap::{respan, Span};

--- a/ioreg/src/lib.rs
+++ b/ioreg/src/lib.rs
@@ -327,7 +327,7 @@ N => NAME
 
 */
 
-#![feature(quote, plugin_registrar, rustc_private, convert)]
+#![feature(quote, plugin_registrar, rustc_private)]
 #![feature(plugin)]
 
 #![plugin(syntaxext_lint)]

--- a/macro_platformtree/src/lib.rs
+++ b/macro_platformtree/src/lib.rs
@@ -76,7 +76,7 @@ fn macro_zinc_task(cx: &mut ExtCtxt, _: Span, _: &ast::MetaItem,
 
 fn macro_zinc_task_item(cx: &mut ExtCtxt, it: P<ast::Item>) -> P<ast::Item> {
   match it.node {
-    ast::ItemFn(ref decl, style, constness, abi, _, ref block) => {
+    ast::ItemKind::Fn(ref decl, style, constness, abi, _, ref block) => {
       let istr = it.ident.name.as_str();
       let fn_name = &*istr;
       let ty_params = platformtree::builder::meta_args::get_ty_params_for_task(cx, fn_name);
@@ -103,7 +103,7 @@ fn macro_zinc_task_item(cx: &mut ExtCtxt, it: P<ast::Item>) -> P<ast::Item> {
                   }).collect(),
                   vec!())),
           None,
-          ast::MutImmutable));
+          ast::Mutability::Immutable));
       let new_decl = P(ast::FnDecl {
         inputs: vec!(new_arg),
         ..decl.deref().clone()
@@ -117,7 +117,7 @@ fn macro_zinc_task_item(cx: &mut ExtCtxt, it: P<ast::Item>) -> P<ast::Item> {
           predicates: vec!(),
         }
       };
-      let new_node = ast::ItemFn(new_decl, style, constness, abi, new_generics, block.clone());
+      let new_node = ast::ItemKind::Fn(new_decl, style, constness, abi, new_generics, block.clone());
 
       P(ast::Item {node: new_node, ..it.deref().clone() })
     },

--- a/macro_platformtree/src/lib.rs
+++ b/macro_platformtree/src/lib.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(rustc_private, plugin_registrar, quote, convert)]
+#![feature(rustc_private, plugin_registrar, quote)]
 
 extern crate platformtree;
 extern crate rustc;

--- a/platformtree/src/lib.rs
+++ b/platformtree/src/lib.rs
@@ -15,7 +15,7 @@
 
 //! Platform tree operations crate
 
-#![feature(quote, rustc_private, convert)]
+#![feature(quote, rustc_private)]
 
 // extern crate regex;
 extern crate syntax;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 #![feature(asm, lang_items, plugin)]
-#![feature(core_intrinsics, core_slice_ext, core_str_ext)]
+#![feature(core_intrinsics, core_slice_ext)]
 #![allow(improper_ctypes)]
 #![feature(const_fn)]
 #![deny(missing_docs)]

--- a/src/util/lang_items.rs
+++ b/src/util/lang_items.rs
@@ -17,16 +17,8 @@
 use core::fmt::Arguments;
 
 #[cfg(all(not(test), not(feature = "test")))]
-#[lang="stack_exhausted"]
-extern fn stack_exhausted() {}
-
-#[cfg(all(not(test), not(feature = "test")))]
 #[lang="eh_personality"]
 extern fn eh_personality() {}
-
-#[cfg(all(not(test), not(feature = "test")))]
-#[lang="begin_unwind"]
-extern fn begin_unwind() {}
 
 #[cfg(all(not(test), not(feature = "test")))]
 #[lang="panic_fmt"]


### PR DESCRIPTION
Yet another module needed updating.

Examples don't compile yet, but it's getting closer.
