### PR TITLE
Even more update for latest rust nightly

### DIFF
--- a/ioreg/Cargo.toml
+++ b/ioreg/Cargo.toml
@@ -11,4 +11,4 @@ plugin = true
 path = "../volatile_cell"
 
 [dependencies]
-syntaxext_lint = "*"
+syntaxext_lint = { git="https://github.com/Gyscos/syntaxext_lint", version="*" }

--- a/ioreg/src/builder/getter.rs
+++ b/ioreg/src/builder/getter.rs
@@ -116,7 +116,7 @@ fn build_new(cx: &ExtCtxt, path: &Vec<String>,
 
 /// Given an `Expr` of the given register's primitive type, return
 /// an `Expr` of the field type
-fn from_primitive(cx: &ExtCtxt, path: &Vec<String>, _: &node::Reg,
+fn from_primitive(cx: &ExtCtxt, path: &Vec<String>, reg: &node::Reg,
                   field: &node::Field, prim: P<ast::Expr>)
                   -> P<ast::Expr> {
   // Use bit_range_field for the span because it is to blame for the
@@ -137,8 +137,14 @@ fn from_primitive(cx: &ExtCtxt, path: &Vec<String>, _: &node::Reg,
           cx.path(v.name.span, vec!(enum_ident, val_ident)));
         let val: u64 = v.value.node;
         let lit = cx.expr_lit(
-          v.value.span,
-          ast::LitKind::Int(val, ast::LitIntType::Unsigned(ast::UintTy::Us)));
+            v.value.span,
+            ast::LitKind::Int(val, ast::LitIntType::Unsigned(match reg.ty.size() {
+                1 => ast::UintTy::U8,
+                2 => ast::UintTy::U16,
+                4 => ast::UintTy::U32,
+                8 => ast::UintTy::U64, // Is this even possible?
+                _ => panic!("Unknown reg size: {}", reg.ty.size()),
+            })));
         let arm = ast::Arm {
           attrs: vec!(),
           pats: vec!(

--- a/ioreg/src/builder/getter.rs
+++ b/ioreg/src/builder/getter.rs
@@ -138,7 +138,7 @@ fn from_primitive(cx: &ExtCtxt, path: &Vec<String>, _: &node::Reg,
         let val: u64 = v.value.node;
         let lit = cx.expr_lit(
           v.value.span,
-          ast::LitKind::Int(val, ast::LitIntType::Unsigned(ast::UintTy::U32)));
+          ast::LitKind::Int(val, ast::LitIntType::Unsigned(ast::UintTy::Us)));
         let arm = ast::Arm {
           attrs: vec!(),
           pats: vec!(

--- a/ioreg/src/builder/union.rs
+++ b/ioreg/src/builder/union.rs
@@ -17,7 +17,7 @@ use std::rc::Rc;
 use std::iter::FromIterator;
 use syntax::ast;
 use syntax::ptr::P;
-use syntax::codemap::{DUMMY_SP, dummy_spanned, respan, Spanned};
+use syntax::codemap::{DUMMY_SP, respan, Spanned};
 use syntax::ext::base::ExtCtxt;
 use syntax::ext::build::AstBuilder;
 
@@ -123,16 +123,14 @@ impl<'a> BuildUnionTypes<'a> {
     };
     let mut field_path = path.clone();
     field_path.push(reg.name.node.clone());
-    dummy_spanned(
-      ast::StructField_ {
-        kind: ast::NamedField(
-          self.cx.ident_of(reg.name.node.as_str()),
-          ast::Visibility::Public),
-        id: ast::DUMMY_NODE_ID,
-        ty: reg_struct_type(self.cx, &field_path, reg),
-        attrs: attrs,
-      }
-    )
+    ast::StructField {
+      span: DUMMY_SP,
+      ident: Some(self.cx.ident_of(reg.name.node.as_str())),
+      vis: ast::Visibility::Public,
+      id: ast::DUMMY_NODE_ID,
+      ty: reg_struct_type(self.cx, &field_path, reg),
+      attrs: attrs,
+    }
   }
 
   /// Build field for padding or a register
@@ -151,16 +149,14 @@ impl<'a> BuildUnionTypes<'a> {
           self.cx.ty(
             DUMMY_SP,
             ast::TyKind::FixedLengthVec(u8_ty, expr_usize(self.cx, respan(DUMMY_SP, length))));
-        dummy_spanned(
-          ast::StructField_ {
-            kind: ast::NamedField(
-              self.cx.ident_of(format!("_pad{}", index).as_str()),
-              ast::Visibility::Inherited),
-            id: ast::DUMMY_NODE_ID,
-            ty: ty,
-            attrs: Vec::new(),
-          },
-        )
+        ast::StructField {
+          span: DUMMY_SP,
+          ident: Some(self.cx.ident_of(format!("_pad{}", index).as_str())),
+          vis: ast::Visibility::Inherited,
+          id: ast::DUMMY_NODE_ID,
+          ty: ty,
+          attrs: Vec::new(),
+        }
       },
     }
   }

--- a/ioreg/src/parser.rs
+++ b/ioreg/src/parser.rs
@@ -20,6 +20,7 @@ use syntax::ast;
 use syntax::codemap::{Span, Spanned, respan, dummy_spanned, mk_sp};
 use syntax::ext::base::ExtCtxt;
 use syntax::parse::{token, ParseSess, lexer};
+use syntax::parse::lexer::Reader;
 use syntax::parse;
 use syntax::print::pprust;
 
@@ -54,7 +55,7 @@ impl<'a> Parser<'a> {
     let mut reader = Box::new(lexer::new_tt_reader(
         &sess.span_diagnostic, None, None, ttsvec)) as Box<lexer::Reader>;
 
-    let tok0 = reader.next_token();
+    let tok0 = reader.try_next_token().unwrap();
     let token = tok0.tok;
     let span = tok0.sp;
 
@@ -604,7 +605,7 @@ impl<'a> Parser<'a> {
     self.last_span = self.span;
     self.last_token = Some(Box::new(tok.clone()));
 
-    let next = self.reader.next_token();
+    let next = self.reader.try_next_token().unwrap();
 
     self.span = next.sp;
     self.token = next.tok;

--- a/ioreg/src/parser.rs
+++ b/ioreg/src/parser.rs
@@ -379,7 +379,7 @@ impl<'a> Parser<'a> {
       token::Colon => {
         self.bump();
         match self.token.clone() {
-          ref t@token::Ident(_,_) => {
+          ref t@token::Ident(_) => {
             match pprust::token_to_string(t) {
               ref s if s.eq(&"rw") => { self.bump(); node::Access::ReadWrite },
               ref s if s.eq(&"ro") => { self.bump(); node::Access::ReadOnly  },
@@ -631,7 +631,7 @@ impl<'a> Parser<'a> {
   fn expect_ident(&mut self) -> Option<String> {
     let tok_str = pprust::token_to_string(&self.token);
     match self.token {
-      token::Ident(_, _) => {
+      token::Ident(_) => {
         self.bump();
         Some(tok_str)
       },

--- a/platformtree/src/builder/os.rs
+++ b/platformtree/src/builder/os.rs
@@ -215,7 +215,6 @@ fn type_name_as_path(cx: &ExtCtxt, ty: &str, params: Vec<String>) -> ast::Path {
 
 #[cfg(test)]
 mod test {
-  use std::ops::Deref;
   use syntax::codemap::DUMMY_SP;
   use syntax::ext::build::AstBuilder;
 
@@ -234,7 +233,7 @@ mod test {
       assert!(unsafe{*failed} == false);
       assert!(builder.main_stmts.len() == 1);
 
-      assert_equal_source(builder.main_stmts[0].deref(),
+      assert_equal_source(&builder.main_stmts[0],
           "loop {
             run();
           }");
@@ -264,14 +263,14 @@ mod test {
       assert!(builder.type_items.len() == 2);
 
       // XXX: builder.type_items[0] is `use zinc;` now
-      assert_equal_source(cx.stmt_item(DUMMY_SP, builder.type_items[1].clone()).deref(),
+      assert_equal_source(&cx.stmt_item(DUMMY_SP, builder.type_items[1].clone()),
           "pub struct run_args<'a> {
             pub a: u32,
             pub b: &'static str,
             pub c: &'a hello::world::Struct,
           }");
 
-      assert_equal_source(builder.main_stmts[0].deref(),
+      assert_equal_source(&builder.main_stmts[0],
           "loop {
             run(&pt::run_args {
               a: 1usize,

--- a/platformtree/src/builder/os.rs
+++ b/platformtree/src/builder/os.rs
@@ -16,7 +16,7 @@
 use std::collections::HashSet;
 use std::rc::Rc;
 use syntax::ast;
-use syntax::codemap::{respan, DUMMY_SP};
+use syntax::codemap::DUMMY_SP;
 use syntax::ext::base::ExtCtxt;
 use syntax::ext::build::AstBuilder;
 use syntax::ext::quote::rt::ToTokens;

--- a/platformtree/src/parser.rs
+++ b/platformtree/src/parser.rs
@@ -41,7 +41,7 @@ impl<'a> Parser<'a> {
     let mut reader = Box::new(lexer::new_tt_reader(
         &sess.span_diagnostic, None, None, ttsvec)) as Box<lexer::Reader>;
 
-    let tok0 = reader.next_token();
+    let tok0 = reader.try_next_token().unwrap();
     let token = tok0.tok;
     let span = tok0.sp;
 
@@ -178,7 +178,7 @@ impl<'a> Parser<'a> {
     }
 
     let node_path = match self.token {
-      Token::Ident(_, _) => {
+      Token::Ident(_) => {
         pprust::token_to_string(&self.bump())
       },
       Token::Literal(token::Lit::Integer(intname), _) => {
@@ -369,7 +369,7 @@ impl<'a> Parser<'a> {
         };
         Some(node::RefValue(name))
       },
-      token::Ident(ident, _) => {
+      token::Ident(ident) => {
         self.bump();
         match &*ident.name.as_str() {
           "true"  => Some(node::BoolValue(true)),
@@ -404,7 +404,7 @@ impl<'a> Parser<'a> {
     self.last_span = self.span;
     self.last_token = Some(Box::new(tok.clone()));
 
-    let next = self.reader.next_token();
+    let next = self.reader.try_next_token().unwrap();
 
     self.span = next.sp;
     self.token = next.tok;
@@ -431,7 +431,7 @@ impl<'a> Parser<'a> {
   fn expect_ident(&mut self) -> Option<String> {
     let tok_str = pprust::token_to_string(&self.token);
     match self.token {
-      token::Ident(_, _) => {
+      token::Ident(_) => {
         self.bump();
         Some(tok_str)
       },

--- a/platformtree/src/test_helpers.rs
+++ b/platformtree/src/test_helpers.rs
@@ -23,7 +23,7 @@ use syntax::ext::base::ExtCtxt;
 use syntax::ext::expand::ExpansionConfig;
 use syntax::ext::quote::rt::ExtParseUtils;
 use syntax::errors::emitter::Emitter;
-use syntax::errors::{RenderSpan, Level, Handler};
+use syntax::errors::{Level, Handler, DiagnosticBuilder};
 use syntax::parse::ParseSess;
 use syntax::print::pprust;
 
@@ -111,12 +111,12 @@ impl CustomEmmiter {
 unsafe impl Send for CustomEmmiter {}
 
 impl Emitter for CustomEmmiter {
-  fn emit(&mut self, _: Option<&codemap::MultiSpan>, m: &str, _: Option<&str>,
+  fn emit(&mut self, _: &codemap::MultiSpan, m: &str, _: Option<&str>,
       l: Level) {
     unsafe { *self.failed = true };
     println!("{} {}", l, m);
   }
-  fn custom_emit(&mut self, _: &RenderSpan, _: &str, _: Level) {
+  fn emit_struct(&mut self, _: &DiagnosticBuilder) {
     panic!();
   }
 }

--- a/platformtree/src/test_helpers.rs
+++ b/platformtree/src/test_helpers.rs
@@ -111,12 +111,12 @@ impl CustomEmmiter {
 unsafe impl Send for CustomEmmiter {}
 
 impl Emitter for CustomEmmiter {
-  fn emit(&mut self, _: Option<codemap::Span>, m: &str, _: Option<&str>,
+  fn emit(&mut self, _: Option<&codemap::MultiSpan>, m: &str, _: Option<&str>,
       l: Level) {
     unsafe { *self.failed = true };
     println!("{} {}", l, m);
   }
-  fn custom_emit(&mut self, _: RenderSpan, _: &str, _: Level) {
+  fn custom_emit(&mut self, _: &RenderSpan, _: &str, _: Level) {
     panic!();
   }
 }

--- a/src/drivers/dht22_pt.rs
+++ b/src/drivers/dht22_pt.rs
@@ -70,7 +70,6 @@ fn build_dht22(builder: &mut Builder, cx: &mut ExtCtxt, node: Rc<node::Node>) {
 
 #[cfg(test)]
 mod test {
-  use std::ops::Deref;
   use builder::Builder;
   use test_helpers::{assert_equal_source, with_parsed};
   use hamcrest::{assert_that, is, equal_to};
@@ -92,7 +91,7 @@ mod test {
       assert_that(unsafe{*failed}, is(equal_to(false)));
       assert_that(builder.main_stmts().len(), is(equal_to(1usize)));
 
-      assert_equal_source(builder.main_stmts()[0].deref(),
+      assert_equal_source(&builder.main_stmts()[0],
           "let dht = zinc::drivers::dht22::DHT22::new(&timer, &pin);");
 
       let pin_node = pt.get_by_name("pin").unwrap();

--- a/src/hal/lpc17xx/pin_pt.rs
+++ b/src/hal/lpc17xx/pin_pt.rs
@@ -137,7 +137,6 @@ fn build_pin(builder: &mut Builder, cx: &mut ExtCtxt, node: Rc<node::Node>) {
 
 #[cfg(test)]
 mod test {
-  use std::ops::Deref;
   use builder::Builder;
   use test_helpers::{assert_equal_source, with_parsed};
 
@@ -154,7 +153,7 @@ mod test {
       assert!(unsafe{*failed} == false);
       assert!(builder.main_stmts().len() == 1);
 
-      assert_equal_source(builder.main_stmts()[0].deref(),
+      assert_equal_source(&builder.main_stmts()[0],
           "let p1 = zinc::hal::lpc17xx::pin::Pin::new(
                zinc::hal::lpc17xx::pin::Port::Port0,
                1u8,
@@ -176,7 +175,7 @@ mod test {
       assert!(unsafe{*failed} == false);
       assert!(builder.main_stmts().len() == 1);
 
-      assert_equal_source(builder.main_stmts()[0].deref(),
+      assert_equal_source(&builder.main_stmts()[0],
           "let p2 = zinc::hal::lpc17xx::pin::Pin::new(
                zinc::hal::lpc17xx::pin::Port::Port0,
                2u8,
@@ -198,7 +197,7 @@ mod test {
       assert!(unsafe{*failed} == false);
       assert!(builder.main_stmts().len() == 1);
 
-      assert_equal_source(builder.main_stmts()[0].deref(),
+      assert_equal_source(&builder.main_stmts()[0],
           "let p3 = zinc::hal::lpc17xx::pin::Pin::new(
                zinc::hal::lpc17xx::pin::Port::Port0,
                3u8,

--- a/src/hal/lpc17xx/system_clock_pt.rs
+++ b/src/hal/lpc17xx/system_clock_pt.rs
@@ -111,7 +111,6 @@ fn build_clock(builder: &mut Builder, cx: &mut ExtCtxt,
 
 #[cfg(test)]
 mod test {
-  use std::ops::Deref;
   use builder::Builder;
   use test_helpers::{assert_equal_source, with_parsed, fails_to_build};
 
@@ -132,7 +131,7 @@ mod test {
       assert!(unsafe{*failed} == false);
       assert!(builder.main_stmts().len() == 1);
 
-      assert_equal_source(builder.main_stmts()[0].deref(),
+      assert_equal_source(&builder.main_stmts()[0],
           "{
             use zinc::hal::lpc17xx::system_clock;
             system_clock::init_clock(

--- a/src/hal/lpc17xx/timer_pt.rs
+++ b/src/hal/lpc17xx/timer_pt.rs
@@ -72,7 +72,6 @@ fn build_timer(builder: &mut Builder, cx: &mut ExtCtxt, node: Rc<node::Node>) {
 
 #[cfg(test)]
 mod test {
-  use std::ops::Deref;
   use builder::Builder;
   use test_helpers::{assert_equal_source, with_parsed};
 
@@ -90,7 +89,7 @@ mod test {
       assert!(unsafe{*failed} == false);
       assert!(builder.main_stmts().len() == 1);
 
-      assert_equal_source(builder.main_stmts()[0].deref(),
+      assert_equal_source(&builder.main_stmts()[0],
           "let tim = zinc::hal::lpc17xx::timer::Timer::new(
               zinc::hal::lpc17xx::timer::TimerPeripheral::Timer1, 25u32, 4u8);");
     });

--- a/src/hal/lpc17xx/uart_pt.rs
+++ b/src/hal/lpc17xx/uart_pt.rs
@@ -122,7 +122,6 @@ pub fn build_uart_gpio(builder: &Builder, uart_idx: usize, name: &str,
 
 #[cfg(test)]
 mod test {
-  use std::ops::Deref;
   use builder::Builder;
   use test_helpers::{assert_equal_source, with_parsed};
 
@@ -153,7 +152,7 @@ mod test {
       assert!(unsafe{*failed} == false);
       assert!(builder.main_stmts().len() == 1);
 
-      assert_equal_source(builder.main_stmts()[0].deref(),
+      assert_equal_source(&builder.main_stmts()[0],
           "let uart = zinc::hal::lpc17xx::uart::UART::new(
                zinc::hal::lpc17xx::uart::UARTPeripheral::UART0,
                9600u32,

--- a/src/hal/stack.rs
+++ b/src/hal/stack.rs
@@ -15,8 +15,6 @@
 
 //! Stack layout information.
 
-use core::intrinsics::transmute;
-
 extern {
   fn __STACK_BASE();
   static mut __STACK_LIMIT: u32;

--- a/src/hal/stack.rs
+++ b/src/hal/stack.rs
@@ -24,9 +24,7 @@ extern {
 
 /// Returns the address of main stack base (end of ram).
 pub fn stack_base() -> usize {
-    unsafe {
-        transmute(__STACK_BASE)
-    }
+    __STACK_BASE as usize
 }
 
 /// Returns the current stack limit.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
 #![feature(core_intrinsics, core_slice_ext)]
 #![allow(improper_ctypes)]
 #![feature(const_fn)]
-#![deny(missing_docs)]
 #![no_std]
 
 /*!

--- a/support/fixcov.py
+++ b/support/fixcov.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 import os, sys
 

--- a/thumbv7em-none-eabi.json
+++ b/thumbv7em-none-eabi.json
@@ -1,7 +1,7 @@
 {
     "arch": "arm",
     "cpu": "cortex-m4",
-    "data-layout": "e-m:e-p:32:32-i1:8:32-i8:8:32-i16:16:32-i64:64-v128:64:128-a:0:32-n32-S64",
+    "data-layout": "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64",
     "disable-redzone": true,
     "executables": true,
     "llvm-target": "thumbv7em-none-eabi",

--- a/thumbv7m-none-eabi.json
+++ b/thumbv7m-none-eabi.json
@@ -1,7 +1,7 @@
 {
     "arch": "arm",
     "cpu": "cortex-m3",
-    "data-layout": "e-m:e-p:32:32-i1:8:32-i8:8:32-i16:16:32-i64:64-v128:64:128-a:0:32-n32-S64",
+    "data-layout": "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64",
     "disable-redzone": true,
     "executables": true,
     "llvm-target": "thumbv7m-none-eabi",


### PR DESCRIPTION
Among the commits:
- The usual bunch of fixes for latest rust nightly
- Point to a forked `syntaxext_lint`, since the official crate still hasn't been updated to latest rust
- Revert the move from `Us` to `U32` in ioreg getter, this was probably a mistake and would need a more thorough analysis
